### PR TITLE
Improvements for Variant

### DIFF
--- a/include/ely/atmosphere.hpp
+++ b/include/ely/atmosphere.hpp
@@ -289,13 +289,13 @@ public:
             if constexpr (position == AtmospherePosition::Leading)
             {
                 return [](LexemeKind kind) {
-                    return lexeme_is_leading_atmosphere(kind);
+                    return kind.is_leading_atmosphere();
                 };
             }
             else if constexpr (position == AtmospherePosition::Trailing)
             {
                 return [](LexemeKind kind) {
-                    return lexeme_is_trailing_atmosphere(kind);
+                    return kind.is_trailing_atmosphere();
                 };
             }
         }();

--- a/include/ely/atmosphere.hpp
+++ b/include/ely/atmosphere.hpp
@@ -31,7 +31,8 @@ public:
     constexpr Whitespace([[maybe_unused]] Lexeme<I> lex)
         : Whitespace(lex.size())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::Whitespace, "expected Whitespace");
+        ELY_ASSERT(ely::holds_alternative<lexeme::Whitespace>(lex.kind),
+                   "expected Whitespace");
     }
 
     constexpr std::size_t size() const
@@ -56,7 +57,8 @@ public:
     template<typename I>
     explicit constexpr Tab(Lexeme<I> lex) : len(lex.size())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::Tab, "expected Tab");
+        ELY_ASSERT(ely::holds_alternative<lexeme::Tab>(lex.kind),
+                   "expected Tab");
     }
 
     constexpr std::size_t size() const
@@ -73,7 +75,8 @@ public:
     template<typename I>
     explicit constexpr NewlineCr([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::NewlineCr, "expected NewlineCr");
+        ELY_ASSERT(ely::holds_alternative<lexeme::NewlineCr>(lex.kind),
+                   "expected NewlineCr");
     }
 
     static constexpr std::string_view str() noexcept
@@ -95,7 +98,8 @@ public:
     template<typename I>
     explicit constexpr NewlineLf([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::NewlineLf, "expected NewlineLf");
+        ELY_ASSERT(ely::holds_alternative<lexeme::NewlineLf>(lex.kind),
+                   "expected NewlineLf");
     }
 
     static constexpr std::string_view str() noexcept
@@ -117,7 +121,8 @@ public:
     template<typename I>
     explicit constexpr NewlineCrlf([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::NewlineCrlf, "expected NewlineCrlf");
+        ELY_ASSERT(ely::holds_alternative<lexeme::NewlineCrlf>(lex.kind),
+                   "expected NewlineCrlf");
     }
 
     static constexpr std::string_view str() noexcept
@@ -142,7 +147,8 @@ public:
     template<typename I>
     explicit constexpr Comment(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::Comment, "expected Comment");
+        ELY_ASSERT(ely::holds_alternative<lexeme::Comment>(lex.kind),
+                   "expected Comment");
     }
 
     template<typename... Args>
@@ -186,49 +192,69 @@ public:
               ELY_ASSERT(ely::lexeme_is_atmosphere(lex.kind),
                          "Atmosphere must be made from atmosphere");
 
-              switch (lex.kind)
-              {
-              case LexemeKind::Whitespace:
-                  return atmosphere::Whitespace(lex);
-              case LexemeKind::Tab:
-                  return atmosphere::Tab(lex);
-              case LexemeKind::NewlineCr:
-                  return atmosphere::NewlineCr(lex);
-              case LexemeKind::NewlineLf:
-                  return atmosphere::NewlineLf(lex);
-              case LexemeKind::NewlineCrlf:
-                  return atmosphere::NewlineCrlf(lex);
-              case LexemeKind::Comment:
-                  return atmosphere::Comment(lex);
-              default:
-                  // this condition has been checked by the assert above
-                  __builtin_unreachable();
-              }
+              using ely::visit;
+              return visit(
+                  [&](auto l) -> VariantType {
+                      using lex_ty = decltype(l);
+                      if constexpr (std::is_same_v<lexeme::Whitespace, lex_ty>)
+                      {
+                          return atmosphere::Whitespace(lex);
+                      }
+                      else if constexpr (std::is_same_v<lexeme::Tab, lex_ty>)
+                      {
+                          return atmosphere::Tab(lex);
+                      }
+                      else if constexpr (std::is_same_v<lexeme::NewlineCr,
+                                                        lex_ty>)
+                      {
+                          return atmosphere::NewlineCr(lex);
+                      }
+                      else if constexpr (std::is_same_v<lexeme::NewlineLf,
+                                                        lex_ty>)
+                      {
+                          return atmosphere::NewlineLf(lex);
+                      }
+                      else if constexpr (std::is_same_v<lexeme::NewlineCrlf,
+                                                        lex_ty>)
+                      {
+                          return atmosphere::NewlineCrlf(lex);
+                      }
+                      else if constexpr (std::is_same_v<lexeme::Comment,
+                                                        lex_ty>)
+                      {
+                          return atmosphere::Comment(lex);
+                      }
+                      else
+                      {
+                          __builtin_unreachable();
+                      }
+                  },
+                  lex.kind);
           }(lexeme))
     {}
 
     template<typename F>
     constexpr auto visit(F&& fn) const& -> decltype(auto)
     {
-        return ely::visit(variant_, static_cast<F&&>(fn));
+        return ely::visit(static_cast<F&&>(fn), variant_);
     }
 
     template<typename F>
     constexpr auto visit(F&& fn) & -> decltype(auto)
     {
-        return ely::visit(variant_, static_cast<F&&>(fn));
+        return ely::visit(static_cast<F&&>(fn), variant_);
     }
 
     template<typename F>
     constexpr auto visit(F&& fn) && -> decltype(auto)
     {
-        return ely::visit(std::move(variant_), static_cast<F&&>(fn));
+        return ely::visit(static_cast<F&&>(fn), std::move(variant_));
     }
 
     template<typename F>
     constexpr auto visit(F&& fn) const&& -> decltype(auto)
     {
-        return ely::visit(std::move(variant_), static_cast<F&&>(fn));
+        return ely::visit(static_cast<F&&>(fn), std::move(variant_));
     }
 
     constexpr std::size_t size() const

--- a/include/ely/pair.hpp
+++ b/include/ely/pair.hpp
@@ -10,37 +10,93 @@ namespace ely
 {
 namespace detail
 {
-/// A box which can be tagged to prevent nasty inheritance issues
-template<int I, typename T, bool Empty = std::is_empty_v<T>>
+/// This box enables the use of EBO, the idea is when a type is not empty it
+/// will not be used as a base and when a type is empty it can be the base of
+/// this Box.
+/// In the case that both types T1 and T2 are equal and they are an empty type
+/// thus suitable for performing EBO, the second box will not inherit or contain
+/// any type, therefore both first() and second() sharing the same location in
+/// memory.
+template<int I,
+         typename T1,
+         typename T2,
+         bool Empty = std::is_empty_v<std::conditional_t<I == 0, T1, T2>>>
 class PairBox;
 
-template<int I, typename T>
-class PairBox<I, T, true> : private T
+template<int I, typename T1, typename T2>
+class PairBox<I, T1, T2, true> : private std::conditional_t<I == 0, T1, T2>
 {
+private:
+    using base_ = std::conditional_t<I == 0, T1, T2>;
+
+    using value_type = base_;
+
 public:
+    PairBox() = default;
+
     template<typename... Args>
     ELY_ALWAYS_INLINE explicit constexpr PairBox(Args&&... args)
-        : T(static_cast<Args&&>(args)...)
+        : base_(static_cast<Args&&>(args)...)
     {}
 
     template<typename Tuple, std::size_t... Is>
     ELY_ALWAYS_INLINE explicit constexpr PairBox(Tuple&& t,
                                                  std::index_sequence<Is...>)
-        : T(std::get<Is>(static_cast<Tuple&&>(t))...)
+        : base_(std::get<Is>(static_cast<Tuple&&>(t))...)
     {}
 
-    ELY_ALWAYS_INLINE constexpr const T& get() const& noexcept
+    ELY_ALWAYS_INLINE constexpr value_type& get() & noexcept
     {
-        return static_cast<T&>(*this);
+        return static_cast<value_type&>(*this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr const value_type& get() const& noexcept
+    {
+        return static_cast<const value_type&>(*this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr value_type&& get() && noexcept
+    {
+        return static_cast<value_type&&>(*this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr const value_type&& get() const&& noexcept
+    {
+        return static_cast<const value_type&&>(*this);
     }
 };
 
-template<int I, typename T>
-class PairBox<I, T, false>
+template<typename T>
+class PairBox<1, T, T, true>
 {
-    T value;
+public:
+    PairBox() = default;
+
+    template<typename... Args>
+    explicit constexpr PairBox(Args&&... args) noexcept(
+        std::is_nothrow_constructible_v<T, Args...>)
+    {
+        T(static_cast<Args&&>(args)...);
+    }
+
+    template<typename Tuple, std::size_t... Is>
+    explicit constexpr PairBox(Tuple&& t, std::index_sequence<Is...>)
+    {
+        T(std::get<Is>(static_cast<Tuple&&>(t))...);
+    }
+};
+
+template<int I, typename T1, typename T2>
+class PairBox<I, T1, T2, false>
+{
+    using value_type = std::conditional_t<I == 0, T1, T2>;
+
+private:
+    value_type value;
 
 public:
+    PairBox() = default;
+
     template<typename... Args>
     ELY_ALWAYS_INLINE explicit constexpr PairBox(Args&&... args)
         : value(static_cast<Args&&>(args)...)
@@ -52,9 +108,24 @@ public:
         : value(std::get<Is>(static_cast<Tuple&&>(t))...)
     {}
 
-    ELY_ALWAYS_INLINE constexpr const T& get() const& noexcept
+    ELY_ALWAYS_INLINE constexpr value_type& get() & noexcept
     {
         return value;
+    }
+
+    ELY_ALWAYS_INLINE constexpr const value_type& get() const& noexcept
+    {
+        return value;
+    }
+
+    ELY_ALWAYS_INLINE constexpr value_type&& get() && noexcept
+    {
+        return static_cast<value_type&&>(value);
+    }
+
+    ELY_ALWAYS_INLINE constexpr const value_type&& get() const&& noexcept
+    {
+        return static_cast<const value_type&&>(value);
     }
 };
 } // namespace detail
@@ -63,28 +134,23 @@ public:
 /// types
 /// Very simple implementation for now
 template<typename T1, typename T2>
-class EBOPair : private detail::PairBox<0, T1>, private detail::PairBox<1, T2>
+class EBOPair : private detail::PairBox<0, T1, T2>,
+                private detail::PairBox<1, T1, T2>
 {
-private:
-    using first_box  = detail::PairBox<0, T1>;
-    using second_box = detail::PairBox<1, T2>;
-
 public:
     using first_type  = T1;
     using second_type = T2;
 
 private:
-    ELY_ALWAYS_INLINE constexpr const first_type& cfirst() const noexcept
-    {
-        return static_cast<const detail::PairBox<0, first_type>&>(*this).get();
-    }
+    using first_box  = detail::PairBox<0, T1, T2>;
+    using second_box = detail::PairBox<1, T1, T2>;
 
-    ELY_ALWAYS_INLINE constexpr const second_type& csecond() const noexcept
-    {
-        return static_cast<const detail::PairBox<1, second_type>&>(*this).get();
-    }
+    static constexpr bool same_type_and_empty =
+        std::is_same_v<T1, T2> && std::is_empty_v<T1>;
 
 public:
+    EBOPair() = default;
+
     ELY_ALWAYS_INLINE constexpr EBOPair(const first_type&  t1,
                                         const second_type& t2)
         : first_box(t1), second_box(t2)
@@ -105,44 +171,76 @@ public:
                      std::make_index_sequence<sizeof...(Args2)>{})
     {}
 
-    ELY_ALWAYS_INLINE constexpr const first_type& first() const& noexcept
-    {
-        return cfirst();
-    }
-
     ELY_ALWAYS_INLINE constexpr first_type& first() & noexcept
     {
-        return const_cast<first_type&>(cfirst());
+        return static_cast<first_box&>(*this).get();
     }
 
-    ELY_ALWAYS_INLINE constexpr const first_type&& first() const&& noexcept
+    ELY_ALWAYS_INLINE constexpr const first_type& first() const& noexcept
     {
-        return std::move(cfirst());
+        return static_cast<const first_box&>(*this).get();
     }
 
     ELY_ALWAYS_INLINE constexpr first_type&& first() && noexcept
     {
-        return std::move(first());
+        return static_cast<first_box&&>(*this).get();
     }
 
-    ELY_ALWAYS_INLINE constexpr const second_type& second() const& noexcept
+    ELY_ALWAYS_INLINE constexpr const first_type&& first() const&& noexcept
     {
-        return csecond();
+        return static_cast<const first_box&&>(*this).get();
     }
 
     ELY_ALWAYS_INLINE constexpr second_type& second() & noexcept
     {
-        return const_cast<second_type&>(csecond());
+        if constexpr (std::is_same_v<first_type, second_type> &&
+                      std::is_empty_v<first_type>)
+        {
+            return first();
+        }
+        else
+        {
+            return static_cast<second_box&>(*this).get();
+        }
+    }
+
+    ELY_ALWAYS_INLINE constexpr const second_type& second() const& noexcept
+    {
+        if constexpr (std::is_same_v<first_type, second_type> &&
+                      std::is_empty_v<first_type>)
+        {
+            return first();
+        }
+        else
+        {
+            return static_cast<const second_box&>(*this).get();
+        }
     }
 
     ELY_ALWAYS_INLINE constexpr second_type&& second() && noexcept
     {
-        return std::move(first());
+        if constexpr (std::is_same_v<first_type, second_type> &&
+                      std::is_empty_v<first_type>)
+        {
+            return std::move(*this).first();
+        }
+        else
+        {
+            return static_cast<second_box&&>(*this).get();
+        }
     }
 
     ELY_ALWAYS_INLINE constexpr const second_type&& second() const&& noexcept
     {
-        return std::move(cfirst());
+        if constexpr (std::is_same_v<first_type, second_type> &&
+                      std::is_empty_v<first_type>)
+        {
+            return std::move(*this).first();
+        }
+        else
+        {
+            return static_cast<const second_box&&>(*this).get();
+        }
     }
 };
 

--- a/include/ely/pair.hpp
+++ b/include/ely/pair.hpp
@@ -73,14 +73,15 @@ public:
     PairBox() = default;
 
     template<typename... Args>
-    explicit constexpr PairBox(Args&&... args) noexcept(
+    ELY_ALWAYS_INLINE explicit constexpr PairBox(Args&&... args) noexcept(
         std::is_nothrow_constructible_v<T, Args...>)
     {
         T(static_cast<Args&&>(args)...);
     }
 
     template<typename Tuple, std::size_t... Is>
-    explicit constexpr PairBox(Tuple&& t, std::index_sequence<Is...>)
+    ELY_ALWAYS_INLINE explicit constexpr PairBox(Tuple&& t,
+                                                 std::index_sequence<Is...>)
     {
         T(std::get<Is>(static_cast<Tuple&&>(t))...);
     }
@@ -251,46 +252,49 @@ constexpr std::enable_if_t<I == 0, T1&> get(EBOPair<T1, T2>& p) noexcept
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 0, const T1&>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 0, const T1&>
 get(const EBOPair<T1, T2>& p) noexcept
 {
     return p.first();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 0, T1&&> get(EBOPair<T1, T2>&& p) noexcept
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 0, T1&&>
+get(EBOPair<T1, T2>&& p) noexcept
 {
     return std::move(p).first();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 0, const T1&&>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 0, const T1&&>
 get(const EBOPair<T1, T2>&& p) noexcept
 {
     return std::move(p).first();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 1, T2&> get(EBOPair<T1, T2>& p) noexcept
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 1, T2&>
+get(EBOPair<T1, T2>& p) noexcept
 {
     return p.second();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 1, const T2&>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 1, const T2&>
 get(const EBOPair<T1, T2>& p) noexcept
 {
     return p.second();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 1, T2&&> get(EBOPair<T1, T2>&& p) noexcept
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 1, T2&&>
+get(EBOPair<T1, T2>&& p) noexcept
 {
     return std::move(p).second();
 }
 
 template<std::size_t I, typename T1, typename T2>
-constexpr std::enable_if_t<I == 1, const T2&&>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<I == 1, const T2&&>
 get(const EBOPair<T1, T2>&& p) noexcept
 {
     return std::move(p).second();

--- a/include/ely/reader.hpp
+++ b/include/ely/reader.hpp
@@ -28,7 +28,7 @@ public:
     reference next()
     {
         return tok_stream_.next().visit_all(
-            [&](auto&& tok, auto&& leading, auto&& trailing) {
+            [&](auto&& tok, auto&& leading, auto&& trailing) -> reference {
                 return read(
                     std::move(tok), std::move(leading), std::move(trailing));
             });

--- a/include/ely/scanner.hpp
+++ b/include/ely/scanner.hpp
@@ -12,74 +12,294 @@ namespace ely
 {
 namespace lexeme
 {
+template<typename T, typename = void>
+struct is_lexeme : std::false_type
+{};
+
+template<typename T>
+struct is_lexeme<T, std::void_t<typename T::lexeme_tag>> : std::true_type
+{};
+
+template<typename T>
+inline constexpr bool is_lexeme_v = is_lexeme<T>::value;
+
+template<typename L, typename = void>
+struct is_newline : std::false_type
+{};
+
+template<typename L>
+struct is_newline<L, std::void_t<typename L::newline_tag>> : is_lexeme<L>
+{};
+
+template<typename L>
+inline constexpr bool is_newline_v = is_newline<L>::value;
+
+template<typename L, typename = void>
+struct is_atmosphere : std::false_type
+{};
+
+template<typename L>
+struct is_atmosphere<L, std::void_t<typename L::atmosphere_tag>> : is_lexeme<L>
+{};
+
+template<typename L>
+inline constexpr bool is_atmosphere_v = is_atmosphere<L>::value;
+
+template<typename L, typename = void>
+struct is_trailing_atmosphere : std::false_type
+{};
+
+template<typename L>
+struct is_trailing_atmosphere<L,
+                              std::void_t<typename L::trailing_atmosphere_tag>>
+    : std::true_type
+{};
+
+template<typename L>
+inline constexpr bool is_trailing_atmosphere_v =
+    is_trailing_atmosphere<L>::value;
+
+template<typename L, typename = void>
+struct is_literal : std::false_type
+{};
+
+template<typename L>
+struct is_literal<L, std::void_t<typename L::literal_tag>> : is_lexeme<L>
+{};
+
+template<typename L>
+inline constexpr bool is_literal_v = is_literal<L>::value;
+
+template<typename L, typename = void>
+struct is_identifier : std::false_type
+{};
+
+template<typename L>
+struct is_identifier<L, std::void_t<typename L::identifier_tag>> : is_lexeme<L>
+{};
+
+template<typename L>
+inline constexpr bool is_identifier_v = is_identifier<L>::value;
+
+template<typename L, typename = void>
+struct is_eof : std::false_type
+{};
+
+template<typename L>
+struct is_eof<L, std::void_t<typename L::eof_tag>> : is_lexeme<L>
+{};
+
+template<typename L>
+inline constexpr bool is_eof_v = is_eof<L>::value;
+
 struct Whitespace
-{};
+{
+    using lexeme_tag              = void;
+    using atmosphere_tag          = void;
+    using trailing_atmosphere_tag = void;
+};
 struct Tab
-{};
+{
+    using lexeme_tag              = void;
+    using atmosphere_tag          = void;
+    using trailing_atmosphere_tag = void;
+};
 struct NewlineCr
-{};
+{
+    using lexeme_tag     = void;
+    using newline_tag    = void;
+    using atmosphere_tag = void;
+};
 struct NewlineLf
-{};
+{
+    using lexeme_tag     = void;
+    using newline_tag    = void;
+    using atmosphere_tag = void;
+};
 struct NewlineCrlf
-{};
+{
+    using lexeme_tag     = void;
+    using newline_tag    = void;
+    using atmosphere_tag = void;
+};
 struct Comment
-{};
+{
+    using lexeme_tag              = void;
+    using atmosphere_tag          = void;
+    using trailing_atmosphere_tag = void;
+};
 struct LParen
-{};
+{
+    using lexeme_tag = void;
+};
 struct RParen
-{};
+{
+    using lexeme_tag = void;
+};
 struct LBracket
-{};
+{
+    using lexeme_tag = void;
+};
 struct RBracket
-{};
+{
+    using lexeme_tag = void;
+};
 struct LBrace
-{};
+{
+    using lexeme_tag = void;
+};
 struct RBrace
-{};
+{
+    using lexeme_tag = void;
+};
 struct Identifier
-{};
+{
+    using lexeme_tag     = void;
+    using identifier_tag = void;
+};
 struct IntLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct FloatLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct CharLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct StringLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct KeywordLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct BoolLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct UnterminatedStringLit
-{};
+{
+    using lexeme_tag  = void;
+    using literal_tag = void;
+};
 struct InvalidNumberSign
-{};
+{
+    using lexeme_tag = void;
+};
 struct Eof
-{};
+{
+    using lexeme_tag = void;
+    using eof_tag    = void;
+};
 } // namespace lexeme
 
-using LexemeKind = ely::Variant<lexeme::Whitespace,
-                                lexeme::Tab,
-                                lexeme::NewlineCr,
-                                lexeme::NewlineLf,
-                                lexeme::NewlineCrlf,
-                                lexeme::Comment,
-                                lexeme::LParen,
-                                lexeme::RParen,
-                                lexeme::LBracket,
-                                lexeme::RBracket,
-                                lexeme::LBrace,
-                                lexeme::RBrace,
-                                lexeme::Identifier,
-                                lexeme::IntLit,
-                                lexeme::FloatLit,
-                                lexeme::CharLit,
-                                lexeme::StringLit,
-                                lexeme::KeywordLit,
-                                lexeme::BoolLit,
-                                lexeme::UnterminatedStringLit,
-                                lexeme::InvalidNumberSign,
-                                lexeme::Eof>;
+class LexemeKind : public ely::Variant<lexeme::Whitespace,
+                                       lexeme::Tab,
+                                       lexeme::NewlineCr,
+                                       lexeme::NewlineLf,
+                                       lexeme::NewlineCrlf,
+                                       lexeme::Comment,
+                                       lexeme::LParen,
+                                       lexeme::RParen,
+                                       lexeme::LBracket,
+                                       lexeme::RBracket,
+                                       lexeme::LBrace,
+                                       lexeme::RBrace,
+                                       lexeme::Identifier,
+                                       lexeme::IntLit,
+                                       lexeme::FloatLit,
+                                       lexeme::CharLit,
+                                       lexeme::StringLit,
+                                       lexeme::KeywordLit,
+                                       lexeme::BoolLit,
+                                       lexeme::UnterminatedStringLit,
+                                       lexeme::InvalidNumberSign,
+                                       lexeme::Eof>
+{
+    using base_ = ely::Variant<lexeme::Whitespace,
+                               lexeme::Tab,
+                               lexeme::NewlineCr,
+                               lexeme::NewlineLf,
+                               lexeme::NewlineCrlf,
+                               lexeme::Comment,
+                               lexeme::LParen,
+                               lexeme::RParen,
+                               lexeme::LBracket,
+                               lexeme::RBracket,
+                               lexeme::LBrace,
+                               lexeme::RBrace,
+                               lexeme::Identifier,
+                               lexeme::IntLit,
+                               lexeme::FloatLit,
+                               lexeme::CharLit,
+                               lexeme::StringLit,
+                               lexeme::KeywordLit,
+                               lexeme::BoolLit,
+                               lexeme::UnterminatedStringLit,
+                               lexeme::InvalidNumberSign,
+                               lexeme::Eof>;
+
+public:
+    using base_::base_;
+
+    ELY_ALWAYS_INLINE constexpr bool is_newline() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) { return lexeme::is_newline_v<decltype(lex)>; },
+            *this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_atmosphere() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) { return lexeme::is_atmosphere_v<decltype(lex)>; },
+            *this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_leading_atmosphere() const noexcept
+    {
+        return is_atmosphere();
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_trailing_atmosphere() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) {
+                return lexeme::is_trailing_atmosphere_v<decltype(lex)>;
+            },
+            *this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_literal() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) { return lexeme::is_literal_v<decltype(lex)>; },
+            *this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_eof() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) { return lexeme::is_eof_v<decltype(lex)>; }, *this);
+    }
+
+    ELY_ALWAYS_INLINE constexpr bool is_identifier() const noexcept
+    {
+        return ely::visit(
+            [](auto lex) { return lexeme::is_identifier_v<decltype(lex)>; },
+            *this);
+    }
+};
 
 static_assert(std::is_trivially_destructible_v<LexemeKind>);
 static_assert(std::is_trivially_copy_constructible_v<LexemeKind>);
@@ -89,50 +309,39 @@ static_assert(
 static_assert(sizeof(LexemeKind) == 1);
 
 template<typename Lex>
-ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
-                                             bool>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<lexeme::is_lexeme_v<Lex>, bool>
 lexeme_is_newline(Lex lex)
 {
-    return std::is_same_v<Lex, lexeme::NewlineCr> ||
-           std::is_same_v<Lex, lexeme::NewlineLf> ||
-           std::is_same_v<Lex, lexeme::NewlineCrlf>;
+    return lexeme::is_newline_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_newline(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_newline(lex); }, kind);
+    return kind.is_newline();
 }
 
 template<typename Lex>
-ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
-                                             bool>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<lexeme::is_lexeme_v<Lex>, bool>
 lexeme_is_trailing_atmosphere(Lex lex)
 {
-    return std::is_same_v<Lex, lexeme::Whitespace> ||
-           std::is_same_v<Lex, lexeme::Tab> ||
-           std::is_same_v<Lex, lexeme::Comment>;
+    return lexeme::is_trailing_atmosphere_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_trailing_atmosphere(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_trailing_atmosphere(lex); },
-                 kind);
+    return kind.is_trailing_atmosphere();
 }
 
 template<typename Lex>
-ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
-                                             bool>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<lexeme::is_lexeme_v<Lex>, bool>
 lexeme_is_atmosphere(Lex lex)
 {
-    return lexeme_is_trailing_atmosphere(lex) || lexeme_is_newline(lex);
+    return lexeme::is_atmosphere_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_atmosphere(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_atmosphere(lex); }, kind);
+    return kind.is_atmosphere();
 }
 
 template<typename Lex>
@@ -140,47 +349,36 @@ ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
                                              bool>
 lexeme_is_leading_atmosphere(Lex lex)
 {
-    ELY_MUSTTAIL return lexeme_is_atmosphere(lex);
+    return lexeme::is_atmosphere_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_leading_atmosphere(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_leading_atmosphere(lex); },
-                 kind);
+    return kind.is_leading_atmosphere();
 }
 
 template<typename Lex>
-ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
-                                             bool>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<lexeme::is_lexeme_v<Lex>, bool>
 lexeme_is_literal(Lex lex)
 {
-    return std::is_same_v<Lex, lexeme::IntLit> ||
-           std::is_same_v<Lex, lexeme::FloatLit> ||
-           std::is_same_v<Lex, lexeme::CharLit> ||
-           std::is_same_v<Lex, lexeme::StringLit> ||
-           std::is_same_v<Lex, lexeme::KeywordLit> ||
-           std::is_same_v<Lex, lexeme::BoolLit>;
+    return lexeme::is_literal_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_literal(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_literal(lex); }, kind);
+    return kind.is_literal();
 }
 
 template<typename Lex>
-ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
-                                             bool>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<lexeme::is_lexeme_v<Lex>, bool>
 lexeme_is_eof(Lex lex)
 {
-    return std::is_same_v<Lex, lexeme::Eof>;
+    return lexeme::is_eof_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_eof(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_eof(lex); }, kind);
+    return kind.is_eof();
 }
 
 template<typename Lex>
@@ -188,13 +386,12 @@ ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,
                                              bool>
 lexeme_is_identifier(Lex lex)
 {
-    return std::is_same_v<Lex, lexeme::Identifier>;
+    return lexeme::is_identifier_v<Lex>;
 }
 
 ELY_ALWAYS_INLINE constexpr bool lexeme_is_identifier(LexemeKind kind)
 {
-    using ely::visit;
-    return visit([](auto lex) { return lexeme_is_identifier(lex); }, kind);
+    return kind.is_identifier();
 }
 
 template<typename I>
@@ -211,7 +408,7 @@ public:
 
     explicit constexpr operator bool() const noexcept
     {
-        return !lexeme_is_eof(kind);
+        return !kind.is_eof();
     }
 
     constexpr iterator begin() const

--- a/include/ely/scanner.hpp
+++ b/include/ely/scanner.hpp
@@ -86,7 +86,7 @@ static_assert(std::is_trivially_copy_constructible_v<LexemeKind>);
 static_assert(
     std::is_default_constructible_v<LexemeKind>); // not trivial since index
                                                   // needs to be initialized too
-// static_assert(sizeof(LexemeKind) == 1);
+static_assert(sizeof(LexemeKind) == 1);
 
 template<typename Lex>
 ELY_ALWAYS_INLINE constexpr std::enable_if_t<!std::is_same_v<Lex, LexemeKind>,

--- a/include/ely/scanner.hpp
+++ b/include/ely/scanner.hpp
@@ -81,7 +81,11 @@ using LexemeKind = ely::Variant<lexeme::Whitespace,
                                 lexeme::InvalidNumberSign,
                                 lexeme::Eof>;
 
-// static_assert(std::is_trivial_v<LexemeKind>);
+static_assert(std::is_trivially_destructible_v<LexemeKind>);
+static_assert(std::is_trivially_copy_constructible_v<LexemeKind>);
+static_assert(
+    std::is_default_constructible_v<LexemeKind>); // not trivial since index
+                                                  // needs to be initialized too
 // static_assert(sizeof(LexemeKind) == 1);
 
 template<typename Lex>

--- a/include/ely/span.hpp
+++ b/include/ely/span.hpp
@@ -88,7 +88,7 @@ public:
     ELY_ALWAYS_INLINE constexpr Span() noexcept : data_size_({}, {})
     {}
 
-    ELY_ALWAYS_INLINE explicit constexpr Span(pointer data, size_type sz)
+    ELY_ALWAYS_INLINE constexpr Span(pointer data, size_type sz)
         : data_size_(data, sz)
     {}
 

--- a/include/ely/token.hpp
+++ b/include/ely/token.hpp
@@ -39,7 +39,8 @@ public:
     template<typename I>
     explicit constexpr LParen([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::LParen, "expected LParen");
+        ELY_ASSERT(ely::holds_alternative<lexeme::LParen>(lex.kind),
+                   "expected LParen");
     }
 
     static constexpr std::size_t size()
@@ -56,7 +57,8 @@ public:
     template<typename I>
     explicit constexpr RParen([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::RParen, "expected RParen");
+        ELY_ASSERT(ely::holds_alternative<lexeme::RParen>(lex.kind),
+                   "expected RParen");
     }
 
     static constexpr std::size_t size()
@@ -73,7 +75,8 @@ public:
     template<typename I>
     explicit constexpr LBracket([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::LBracket, "expected LBracket");
+        ELY_ASSERT(ely::holds_alternative<lexeme::LBracket>(lex.kind),
+                   "expected LBracket");
     }
 
     static constexpr std::size_t size()
@@ -90,7 +93,8 @@ public:
     template<typename I>
     explicit constexpr RBracket([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::RBracket, "expected RBracket");
+        ELY_ASSERT(ely::holds_alternative<lexeme::RBracket>(lex.kind),
+                   "expected RBracket");
     }
 
     static constexpr std::size_t size()
@@ -107,7 +111,8 @@ public:
     template<typename I>
     explicit constexpr LBrace([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::LBrace, "expected LBrace");
+        ELY_ASSERT(ely::holds_alternative<lexeme::LBrace>(lex.kind),
+                   "expected LBrace");
     }
 
     static constexpr std::size_t size()
@@ -124,7 +129,8 @@ public:
     template<typename I>
     explicit constexpr RBrace([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::RBrace, "expected RBrace");
+        ELY_ASSERT(ely::holds_alternative<lexeme::RBrace>(lex.kind),
+                   "expected RBrace");
     }
 
     static constexpr std::size_t size()
@@ -144,7 +150,8 @@ public:
     template<typename I>
     explicit constexpr Identifier(Lexeme<I> lex) : name_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::Identifier, "expected Identifier");
+        ELY_ASSERT(ely::holds_alternative<lexeme::Identifier>(lex.kind),
+                   "expected Identifier");
     }
 
     template<typename... Args>
@@ -174,7 +181,8 @@ public:
     template<typename I>
     explicit constexpr IntLit(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::IntLit, "expected IntLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::IntLit>(lex.kind),
+                   "expected IntLit");
     }
 
     template<typename... Args>
@@ -204,7 +212,8 @@ public:
     template<typename I>
     explicit constexpr FloatLit(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::FloatLit, "expected FloatLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::FloatLit>(lex.kind),
+                   "expected FloatLit");
     }
 
     template<typename... Args>
@@ -234,7 +243,8 @@ public:
     template<typename I>
     explicit constexpr CharLit(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::CharLit, "expected CharLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::CharLit>(lex.kind),
+                   "expected CharLit");
     }
 
     template<typename... Args>
@@ -264,7 +274,8 @@ public:
     template<typename I>
     constexpr StringLit(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::StringLit, "expected StringLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::StringLit>(lex.kind),
+                   "expected StringLit");
     }
 
     template<typename... Args>
@@ -294,7 +305,8 @@ public:
     template<typename I>
     explicit constexpr KeywordLit(Lexeme<I> lex) : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::KeywordLit, "expected KeywordLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::KeywordLit>(lex.kind),
+                   "expected KeywordLit");
     }
 
     template<typename... Args>
@@ -326,7 +338,8 @@ public:
     explicit constexpr BoolLit(Lexeme<I> lex)
         : b(*std::next(lex.begin()) == 't')
     {
-        ELY_ASSERT(lex.kind == LexemeKind::BoolLit, "expected BoolLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::BoolLit>(lex.kind),
+                   "expected BoolLit");
     }
 
     explicit constexpr BoolLit(bool b) : b(b)
@@ -361,7 +374,8 @@ public:
     explicit constexpr UnterminatedStringLit(Lexeme<I> lex)
         : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::StringLit, "expected StringLit");
+        ELY_ASSERT(ely::holds_alternative<lexeme::StringLit>(lex.kind),
+                   "expected StringLit");
     }
 
     ELY_CONSTEXPR_STRING std::string_view str() const noexcept
@@ -388,7 +402,7 @@ public:
     explicit constexpr InvalidNumberSign(Lexeme<I> lex)
         : str_(lex.begin(), lex.end())
     {
-        ELY_ASSERT(lex.kind == LexemeKind::InvalidNumberSign,
+        ELY_ASSERT(ely::holds_alternative<lexeme::InvalidNumberSign>(lex.kind),
                    "expected InvalidNumberSign");
     }
 
@@ -411,7 +425,8 @@ public:
     template<typename I>
     explicit constexpr Eof([[maybe_unused]] Lexeme<I> lex)
     {
-        ELY_ASSERT(lex.kind == LexemeKind::Eof, "expected Eof");
+        ELY_ASSERT(ely::holds_alternative<lexeme::Eof>(lex.kind),
+                   "expected Eof");
     }
 
     static constexpr std::size_t size()
@@ -562,33 +577,42 @@ Token make_token(AtmosphereList<AtmospherePosition::Leading>&&  leading,
                  Lexeme<I>                                      lex)
 {
 
+    using ely::visit;
+    return visit(
+        [&](auto l) -> Token {
+            using lex_ty = decltype(l);
+
 #define DISPATCH(tok)                                                          \
-    case LexemeKind::tok:                                                      \
+    if constexpr (std::is_same_v<lexeme::tok, lex_ty>)                         \
+    {                                                                          \
         return Token(std::move(leading),                                       \
                      std::move(trailing),                                      \
                      std::in_place_type<token::tok>,                           \
-                     lex);
-    switch (lex.kind)
-    {
-        DISPATCH(LParen);
-        DISPATCH(RParen);
-        DISPATCH(LBracket);
-        DISPATCH(RBracket);
-        DISPATCH(LBrace);
-        DISPATCH(RBrace);
-        DISPATCH(Identifier);
-        DISPATCH(IntLit);
-        DISPATCH(FloatLit);
-        DISPATCH(CharLit);
-        DISPATCH(StringLit);
-        DISPATCH(KeywordLit);
-        DISPATCH(BoolLit);
-        DISPATCH(InvalidNumberSign);
-        DISPATCH(UnterminatedStringLit);
-        DISPATCH(Eof);
-    default:
-        __builtin_unreachable();
-    }
+                     lex);                                                     \
+    }                                                                          \
+    else
+
+            DISPATCH(LParen)
+            DISPATCH(RParen)
+            DISPATCH(LBracket)
+            DISPATCH(RBracket)
+            DISPATCH(LBrace)
+            DISPATCH(RBrace)
+            DISPATCH(Identifier)
+            DISPATCH(IntLit)
+            DISPATCH(FloatLit)
+            DISPATCH(CharLit)
+            DISPATCH(StringLit)
+            DISPATCH(KeywordLit)
+            DISPATCH(BoolLit)
+            DISPATCH(InvalidNumberSign)
+            DISPATCH(UnterminatedStringLit)
+            DISPATCH(Eof)
+            {
+                __builtin_unreachable();
+            }
+        },
+        lex.kind);
 #undef DISPATCH
 }
 } // namespace ely

--- a/include/ely/union.hpp
+++ b/include/ely/union.hpp
@@ -316,9 +316,9 @@ public:
     // this should enable trivial construction
     UnionStorage() = default;
 
-    using UnionBox<Is, Ts, ely::type_index_v<Ts, Ts...> == Is>::UnionBox...;
+    using UnionBox<Is, Ts, ely::type_index_v<Ts, Ts...> != Is>::UnionBox...;
 
-private:
+public:
     template<std::size_t I>
     constexpr ely::nth_element_t<I, Ts...>&
     get_unchecked(std::in_place_index_t<I>) & noexcept

--- a/include/ely/union.hpp
+++ b/include/ely/union.hpp
@@ -78,6 +78,12 @@ struct CommonAvailability
     static constexpr Availability destructible = common_availability(
         {Available<Ts, std::is_trivially_destructible, std::is_destructible>::
              value...});
+
+    static constexpr Availability default_constructible =
+        sizeof...(Ts) == 0 ? Availability::TriviallyAvailable :
+        std::is_default_constructible_v<ely::nth_element_t<0, Ts...>> ?
+                             Availability::Available :
+                             Availability::Unavailable;
 };
 } // namespace detail
 

--- a/include/ely/union.hpp
+++ b/include/ely/union.hpp
@@ -3,13 +3,11 @@
 #include <memory>
 #include <type_traits>
 
+#include "ely/defines.h"
 #include "ely/utility.hpp"
 
 namespace ely
 {
-template<std::size_t I, typename... Ts>
-using nth_element_t = std::tuple_element_t<I, std::tuple<Ts...>>;
-
 namespace detail
 {
 enum class Availability
@@ -18,6 +16,36 @@ enum class Availability
     Available,
     Unavailable
 };
+
+enum class UnionConfig
+{
+    TriviallyDestructible,
+    Destructible,
+    Undestructible,
+    EBO,
+};
+
+struct UnionConfigToAvailability
+{
+    constexpr Availability operator()(UnionConfig config) const noexcept
+    {
+        switch (config)
+        {
+        case UnionConfig::EBO:
+        case UnionConfig::TriviallyDestructible:
+            return Availability::TriviallyAvailable;
+        case UnionConfig::Destructible:
+            return Availability::Available;
+        case UnionConfig::Undestructible:
+            return Availability::Unavailable;
+        }
+    }
+};
+
+inline constexpr auto union_config_to_availability =
+    UnionConfigToAvailability{};
+
+struct UnionAccess;
 
 template<typename T,
          template<typename>
@@ -85,19 +113,9 @@ struct CommonAvailability
                              Availability::Available :
                              Availability::Unavailable;
 };
-} // namespace detail
 
-namespace detail
-{
 template<ely::detail::Availability A, typename... Ts>
 class UnionDestructor;
-}
-template<typename... Ts>
-class Union;
-
-namespace detail
-{
-struct UnionAccess;
 
 template<ely::detail::Availability A, typename... Ts>
 class UnionDestructor;
@@ -115,7 +133,7 @@ public:
     template<typename T, typename... Ts>                                       \
     class UnionDestructor<available, T, Ts...>                                 \
     {                                                                          \
-        friend struct ::ely::detail::UnionAccess;                              \
+        friend ::ely::detail::UnionAccess;                                     \
                                                                                \
         union                                                                  \
         {                                                                      \
@@ -162,6 +180,63 @@ public:
                          UnionDestructor&                                      \
                          operator=(const UnionDestructor&) = default;          \
         UnionDestructor& operator=(UnionDestructor&&) = default;               \
+                                                                               \
+    public:                                                                    \
+        template<std::size_t I>                                                \
+        constexpr auto&& get_unchecked(std::in_place_index_t<I>) & noexcept    \
+        {                                                                      \
+            if constexpr (I == 0)                                              \
+            {                                                                  \
+                return first_;                                                 \
+            }                                                                  \
+            else                                                               \
+            {                                                                  \
+                return rest_.get_unchecked(std::in_place_index<I - 1>);        \
+            }                                                                  \
+        }                                                                      \
+                                                                               \
+        template<std::size_t I>                                                \
+        constexpr auto&&                                                       \
+            get_unchecked(std::in_place_index_t<I>) const& noexcept            \
+        {                                                                      \
+            if constexpr (I == 0)                                              \
+            {                                                                  \
+                return first_;                                                 \
+            }                                                                  \
+            else                                                               \
+            {                                                                  \
+                return rest_.get_unchecked(std::in_place_index<I - 1>);        \
+            }                                                                  \
+        }                                                                      \
+                                                                               \
+        template<std::size_t I>                                                \
+        constexpr auto&& get_unchecked(std::in_place_index_t<I>) && noexcept   \
+        {                                                                      \
+            if constexpr (I == 0)                                              \
+            {                                                                  \
+                return static_cast<T&&>(first_);                               \
+            }                                                                  \
+            else                                                               \
+            {                                                                  \
+                return std::move(rest_).get_unchecked(                         \
+                    std::in_place_index<I - 1>);                               \
+            }                                                                  \
+        }                                                                      \
+                                                                               \
+        template<std::size_t I>                                                \
+        constexpr auto&&                                                       \
+            get_unchecked(std::in_place_index_t<I>) const&& noexcept           \
+        {                                                                      \
+            if constexpr (I == 0)                                              \
+            {                                                                  \
+                return static_cast<const T&&>(first_);                         \
+            }                                                                  \
+            else                                                               \
+            {                                                                  \
+                return std::move(rest_).get_unchecked(                         \
+                    std::in_place_index<I - 1>);                               \
+            }                                                                  \
+        }                                                                      \
     }
 
 UNION_IMPL(ely::detail::Availability::TriviallyAvailable,
@@ -171,39 +246,200 @@ UNION_IMPL(ely::detail::Availability::Unavailable,
            ~UnionDestructor() = delete;);
 
 #undef UNION_IMPL
-} // namespace detail
-template<typename... Ts>
-class Union : public detail::UnionDestructor<
-                  ely::detail::CommonAvailability<Ts...>::destructible,
-                  Ts...>
+
+template<UnionConfig Config, typename Indices, typename... Ts>
+class UnionStorage;
+
+template<UnionConfig Config, typename Indices, typename... Ts>
+class UnionStorage
+    : private UnionDestructor<union_config_to_availability(Config), Ts...>
 {
-    using base_ = detail::UnionDestructor<
-        ely::detail::CommonAvailability<Ts...>::destructible,
-        Ts...>;
+    friend ::ely::detail::UnionAccess;
+
+    using base_ = UnionDestructor<union_config_to_availability(Config), Ts...>;
 
 public:
     using base_::base_;
+
+protected:
+    using base_::get_unchecked;
+};
+
+template<std::size_t I, typename T, bool CanErase>
+struct UnionBox;
+
+/// this specialization gets used when the trivial and empty element is not the
+/// first of its kind. Without this the resulting union cannot be empty. Special
+/// care must be taken to never access this Box when accessing Union members.
+/// get_unchecked<I>() will need a special check to get the first element of
+/// this type
+template<std::size_t I, typename T>
+struct UnionBox<I, T, true>
+{
+    static_assert(std::is_empty_v<T>, "T must be empty");
+    static_assert(std::is_trivial_v<T>, "T must be trivial");
+
+    UnionBox() = default;
+
+    template<std::size_t J, typename... Args>
+    explicit constexpr UnionBox(std::in_place_index_t<J>, Args&&...)
+    {}
+};
+
+template<std::size_t I, typename T>
+struct UnionBox<I, T, false> : protected T
+{
+    static_assert(std::is_empty_v<T>, "T must be empty");
+    static_assert(std::is_trivial_v<T>, "T must be trivial");
+
+    UnionBox() = default;
+
+    /// ignore if our index wasn't passed
+    template<std::size_t J, typename... Args>
+    explicit constexpr UnionBox(std::in_place_index_t<J>, Args&&...)
+        : UnionBox()
+    {}
+
+    template<typename... Args>
+    explicit constexpr UnionBox(std::in_place_index_t<I>, Args&&... args)
+        : T(static_cast<Args&&>(args)...)
+    {}
+};
+
+template<std::size_t... Is, typename... Ts>
+class UnionStorage<UnionConfig::EBO, std::index_sequence<Is...>, Ts...>
+    : private UnionBox<Is, Ts, ely::type_index_v<Ts, Ts...> != Is>...
+{
+    friend ::ely::detail::UnionAccess;
+
+public:
+    // this should enable trivial construction
+    UnionStorage() = default;
+
+    using UnionBox<Is, Ts, ely::type_index_v<Ts, Ts...> == Is>::UnionBox...;
+
+private:
+    template<std::size_t I>
+    constexpr ely::nth_element_t<I, Ts...>&
+    get_unchecked(std::in_place_index_t<I>) & noexcept
+    {
+        return static_cast<ely::nth_element_t<I, Ts...>&>(*this);
+    }
+
+    template<std::size_t I>
+    constexpr const ely::nth_element_t<I, Ts...>&
+        get_unchecked(std::in_place_index_t<I>) const& noexcept
+    {
+        return static_cast<const ely::nth_element_t<I, Ts...>&>(*this);
+    }
+    template<std::size_t I>
+    constexpr ely::nth_element_t<I, Ts...>&&
+    get_unchecked(std::in_place_index_t<I>) && noexcept
+    {
+        return static_cast<ely::nth_element_t<I, Ts...>&&>(*this);
+    }
+    template<std::size_t I>
+    constexpr const ely::nth_element_t<I, Ts...>&&
+        get_unchecked(std::in_place_index_t<I>) const&& noexcept
+    {
+        return static_cast<const ely::nth_element_t<I, Ts...>&&>(*this);
+    }
+};
+
+struct UnionConfigHelper
+{
+    constexpr UnionConfig
+    operator()(std::initializer_list<bool> trivial_empties,
+               std::initializer_list<bool> trivial_destroys,
+               std::initializer_list<bool> destructibles) const noexcept
+    {
+        bool success = true;
+
+        for (auto triv_empty : trivial_empties)
+        {
+            if (!triv_empty)
+            {
+                success = false;
+                break;
+            }
+        }
+
+        if (success)
+        {
+            return UnionConfig::EBO;
+        }
+
+        success = true;
+
+        for (auto triv_destroy : trivial_destroys)
+        {
+            if (!triv_destroy)
+            {
+                success = false;
+                break;
+            }
+        }
+
+        if (success)
+        {
+            return UnionConfig::TriviallyDestructible;
+        }
+
+        success = true;
+
+        for (auto destructible : destructibles)
+        {
+            if (!destructible)
+            {
+                success = false;
+                break;
+            }
+        }
+
+        if (success)
+        {
+            return UnionConfig::Destructible;
+        }
+
+        return UnionConfig::Undestructible;
+    }
+};
+
+template<typename... Ts>
+inline constexpr UnionConfig union_config_v = UnionConfigHelper{}(
+    {std::conjunction_v<std::is_trivial<Ts>, std::is_empty<Ts>>...},
+    {std::is_trivially_destructible_v<Ts>...},
+    {std::is_destructible_v<Ts>...});
+} // namespace detail
+template<typename... Ts>
+class Union
+    : private detail::UnionStorage<detail::union_config_v<Ts...>,
+                                   std::make_index_sequence<sizeof...(Ts)>,
+                                   Ts...>
+{
+    friend ::ely::detail::UnionAccess;
+
+    using base_ = detail::UnionStorage<detail::union_config_v<Ts...>,
+                                       std::make_index_sequence<sizeof...(Ts)>,
+                                       Ts...>;
+
+public:
+    using base_::base_;
+
+private:
+    using base_::get_unchecked;
 };
 
 namespace detail
 {
 struct UnionAccess
 {
-    template<typename U>
-    static constexpr auto get_unchecked(U&& u,
-                                        std::in_place_index_t<0>) noexcept
-        -> decltype(auto)
-    {
-        return (static_cast<U&&>(u).first_);
-    }
-
     template<typename U, std::size_t I>
-    static constexpr auto get_unchecked(U&& u,
-                                        std::in_place_index_t<I>) noexcept
+    static constexpr auto get_unchecked(U&&                      u,
+                                        std::in_place_index_t<I> idx) noexcept
         -> decltype(auto)
     {
-        return get_unchecked((static_cast<U&&>(u).rest_),
-                             std::in_place_index<I - 1>);
+        return static_cast<U&&>(u).get_unchecked(idx);
     }
 };
 

--- a/include/ely/union.hpp
+++ b/include/ely/union.hpp
@@ -145,28 +145,32 @@ public:
         UnionDestructor() = default;                                           \
                                                                                \
         template<typename... Args>                                             \
-        explicit constexpr UnionDestructor(std::in_place_index_t<0>,           \
-                                           Args&&... args)                     \
+        ELY_ALWAYS_INLINE explicit constexpr UnionDestructor(                  \
+            std::in_place_index_t<0>,                                          \
+            Args&&... args)                                                    \
             : first_(static_cast<Args&&>(args)...)                             \
         {}                                                                     \
         template<typename U, typename... Args>                                 \
-        explicit constexpr UnionDestructor(std::in_place_index_t<0>,           \
-                                           std::initializer_list<U> il,        \
-                                           Args&&... args)                     \
+        ELY_ALWAYS_INLINE explicit constexpr UnionDestructor(                  \
+            std::in_place_index_t<0>,                                          \
+            std::initializer_list<U> il,                                       \
+            Args&&... args)                                                    \
             : first_(il, static_cast<Args&&>(args)...)                         \
         {}                                                                     \
                                                                                \
         template<std::size_t Idx, typename... Args>                            \
-        explicit constexpr UnionDestructor(std::in_place_index_t<Idx>,         \
-                                           Args&&... args)                     \
+        ELY_ALWAYS_INLINE explicit constexpr UnionDestructor(                  \
+            std::in_place_index_t<Idx>,                                        \
+            Args&&... args)                                                    \
             : rest_(std::in_place_index<Idx - 1>,                              \
                     static_cast<Args&&>(args)...)                              \
         {}                                                                     \
                                                                                \
         template<std::size_t I, typename U, typename... Args>                  \
-        explicit constexpr UnionDestructor(std::in_place_index_t<I>,           \
-                                           std::initializer_list<U> il,        \
-                                           Args&&... args)                     \
+        ELY_ALWAYS_INLINE explicit constexpr UnionDestructor(                  \
+            std::in_place_index_t<I>,                                          \
+            std::initializer_list<U> il,                                       \
+            Args&&... args)                                                    \
             : rest_(std::in_place_index<I - 1>,                                \
                     il,                                                        \
                     static_cast<Args&&>(args)...)                              \
@@ -183,7 +187,8 @@ public:
                                                                                \
     public:                                                                    \
         template<std::size_t I>                                                \
-        constexpr auto&& get_unchecked(std::in_place_index_t<I>) & noexcept    \
+        ELY_ALWAYS_INLINE constexpr auto&&                                     \
+        get_unchecked(std::in_place_index_t<I>) & noexcept                     \
         {                                                                      \
             if constexpr (I == 0)                                              \
             {                                                                  \
@@ -196,7 +201,7 @@ public:
         }                                                                      \
                                                                                \
         template<std::size_t I>                                                \
-        constexpr auto&&                                                       \
+        ELY_ALWAYS_INLINE constexpr auto&&                                     \
             get_unchecked(std::in_place_index_t<I>) const& noexcept            \
         {                                                                      \
             if constexpr (I == 0)                                              \
@@ -210,7 +215,8 @@ public:
         }                                                                      \
                                                                                \
         template<std::size_t I>                                                \
-        constexpr auto&& get_unchecked(std::in_place_index_t<I>) && noexcept   \
+        ELY_ALWAYS_INLINE constexpr auto&&                                     \
+        get_unchecked(std::in_place_index_t<I>) && noexcept                    \
         {                                                                      \
             if constexpr (I == 0)                                              \
             {                                                                  \
@@ -224,7 +230,7 @@ public:
         }                                                                      \
                                                                                \
         template<std::size_t I>                                                \
-        constexpr auto&&                                                       \
+        ELY_ALWAYS_INLINE constexpr auto&&                                     \
             get_unchecked(std::in_place_index_t<I>) const&& noexcept           \
         {                                                                      \
             if constexpr (I == 0)                                              \
@@ -282,7 +288,8 @@ struct UnionBox<I, T, true>
     UnionBox() = default;
 
     template<std::size_t J, typename... Args>
-    explicit constexpr UnionBox(std::in_place_index_t<J>, Args&&...)
+    ELY_ALWAYS_INLINE explicit constexpr UnionBox(std::in_place_index_t<J>,
+                                                  Args&&...)
     {}
 };
 
@@ -296,12 +303,14 @@ struct UnionBox<I, T, false> : protected T
 
     /// ignore if our index wasn't passed
     template<std::size_t J, typename... Args>
-    explicit constexpr UnionBox(std::in_place_index_t<J>, Args&&...)
+    ELY_ALWAYS_INLINE explicit constexpr UnionBox(std::in_place_index_t<J>,
+                                                  Args&&...)
         : UnionBox()
     {}
 
     template<typename... Args>
-    explicit constexpr UnionBox(std::in_place_index_t<I>, Args&&... args)
+    ELY_ALWAYS_INLINE explicit constexpr UnionBox(std::in_place_index_t<I>,
+                                                  Args&&... args)
         : T(static_cast<Args&&>(args)...)
     {}
 };
@@ -320,26 +329,26 @@ public:
 
 public:
     template<std::size_t I>
-    constexpr ely::nth_element_t<I, Ts...>&
+    ELY_ALWAYS_INLINE constexpr ely::nth_element_t<I, Ts...>&
     get_unchecked(std::in_place_index_t<I>) & noexcept
     {
         return static_cast<ely::nth_element_t<I, Ts...>&>(*this);
     }
 
     template<std::size_t I>
-    constexpr const ely::nth_element_t<I, Ts...>&
+    ELY_ALWAYS_INLINE constexpr const ely::nth_element_t<I, Ts...>&
         get_unchecked(std::in_place_index_t<I>) const& noexcept
     {
         return static_cast<const ely::nth_element_t<I, Ts...>&>(*this);
     }
     template<std::size_t I>
-    constexpr ely::nth_element_t<I, Ts...>&&
+    ELY_ALWAYS_INLINE constexpr ely::nth_element_t<I, Ts...>&&
     get_unchecked(std::in_place_index_t<I>) && noexcept
     {
         return static_cast<ely::nth_element_t<I, Ts...>&&>(*this);
     }
     template<std::size_t I>
-    constexpr const ely::nth_element_t<I, Ts...>&&
+    ELY_ALWAYS_INLINE constexpr const ely::nth_element_t<I, Ts...>&&
         get_unchecked(std::in_place_index_t<I>) const&& noexcept
     {
         return static_cast<const ely::nth_element_t<I, Ts...>&&>(*this);
@@ -435,8 +444,8 @@ namespace detail
 struct UnionAccess
 {
     template<typename U, std::size_t I>
-    static constexpr auto get_unchecked(U&&                      u,
-                                        std::in_place_index_t<I> idx) noexcept
+    ELY_ALWAYS_INLINE static constexpr auto
+    get_unchecked(U&& u, std::in_place_index_t<I> idx) noexcept
         -> decltype(auto)
     {
         return static_cast<U&&>(u).get_unchecked(idx);
@@ -453,33 +462,37 @@ struct is_union<ely::Union<Ts...>> : std::true_type
 } // namespace detail
 
 template<std::size_t I, typename... Ts>
-constexpr auto get_unchecked(Union<Ts...>& u) noexcept -> decltype(auto)
+ELY_ALWAYS_INLINE constexpr auto get_unchecked(Union<Ts...>& u) noexcept
+    -> decltype(auto)
 {
     return ely::detail::UnionAccess::get_unchecked(u, std::in_place_index<I>);
 }
 
 template<std::size_t I, typename... Ts>
-constexpr auto get_unchecked(const Union<Ts...>& u) noexcept -> decltype(auto)
+ELY_ALWAYS_INLINE constexpr auto get_unchecked(const Union<Ts...>& u) noexcept
+    -> decltype(auto)
 {
     return ely::detail::UnionAccess::get_unchecked(u, std::in_place_index<I>);
 }
 
 template<std::size_t I, typename... Ts>
-constexpr auto get_unchecked(Union<Ts...>&& u) noexcept -> decltype(auto)
+ELY_ALWAYS_INLINE constexpr auto get_unchecked(Union<Ts...>&& u) noexcept
+    -> decltype(auto)
 {
     return ely::detail::UnionAccess::get_unchecked(std::move(u),
                                                    std::in_place_index<I>);
 }
 
 template<std::size_t I, typename... Ts>
-constexpr auto get_unchecked(const Union<Ts...>&& u) noexcept -> decltype(auto)
+ELY_ALWAYS_INLINE constexpr auto get_unchecked(const Union<Ts...>&& u) noexcept
+    -> decltype(auto)
 {
     return ely::detail::UnionAccess::get_unchecked(std::move(u),
                                                    std::in_place_index<I>);
 }
 
 template<std::size_t I, typename... Ts>
-constexpr void destroy(ely::Union<Ts...>& u) noexcept
+ELY_ALWAYS_INLINE constexpr void destroy(ely::Union<Ts...>& u) noexcept
 {
     using ty = ely::nth_element_t<I, Ts...>;
     static_assert(std::is_destructible_v<ty>,
@@ -492,14 +505,14 @@ constexpr void destroy(ely::Union<Ts...>& u) noexcept
 }
 
 template<std::size_t I, typename... Ts, typename... Args>
-constexpr void emplace(ely::Union<Ts...>& u, Args&&... args)
+ELY_ALWAYS_INLINE constexpr void emplace(ely::Union<Ts...>& u, Args&&... args)
 {
     ::new (static_cast<void*>(std::addressof(ely::get_unchecked<I>(u))))
         ely::nth_element_t<I, Ts...>(static_cast<Args&&>(args)...);
 }
 
 template<std::size_t I, typename... Ts, typename U, typename... Args>
-constexpr void
+ELY_ALWAYS_INLINE constexpr void
 emplace(ely::Union<Ts...>& u, std::initializer_list<U> il, Args&&... args)
 {
     ::new (static_cast<void*>(std::addressof(ely::get_unchecked<I>(u))))

--- a/include/ely/utility.hpp
+++ b/include/ely/utility.hpp
@@ -43,6 +43,17 @@ template<typename T, typename... Ts>
 struct type_index : std::integral_constant<std::size_t, type_index_v<T, Ts...>>
 {};
 
+// there's no added template instantiation overhead since all the is_same_v
+// would get instantiated anyway
+template<typename T, typename... Ts>
+inline constexpr std::size_t type_present_v = type_index_v<T, Ts...> !=
+                                              sizeof...(Ts);
+
+template<typename T, typename... Ts>
+struct type_present
+    : std::integral_constant<std::size_t, type_present_v<T, Ts...>>
+{};
+
 namespace detail
 {
 struct type_count_helper

--- a/include/ely/utility.hpp
+++ b/include/ely/utility.hpp
@@ -11,6 +11,9 @@ namespace ely
 template<typename T>
 using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
+template<std::size_t I, typename... Ts>
+using nth_element_t = std::tuple_element_t<I, std::tuple<Ts...>>;
+
 namespace detail
 {
 struct type_index_helper

--- a/include/ely/utility.hpp
+++ b/include/ely/utility.hpp
@@ -3,12 +3,114 @@
 #include "ely/defines.h"
 
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 namespace ely
 {
 template<typename T>
 using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+namespace detail
+{
+struct type_index_helper
+{
+    constexpr std::size_t
+    operator()(std::initializer_list<bool> sames) const noexcept
+    {
+        std::size_t index = 0;
+
+        for (auto same : sames)
+        {
+            if (same)
+            {
+                return index;
+            }
+
+            ++index;
+        }
+
+        return index;
+    }
+};
+} // namespace detail
+
+template<typename T, typename... Ts>
+inline constexpr std::size_t
+    type_index_v = detail::type_index_helper{}({std::is_same_v<T, Ts>...});
+
+template<typename T, typename... Ts>
+struct type_index : std::integral_constant<std::size_t, type_index_v<T, Ts...>>
+{};
+
+namespace detail
+{
+struct type_count_helper
+{
+    constexpr std::size_t
+    operator()(std::initializer_list<bool> sames) const noexcept
+    {
+        std::size_t count = 0;
+
+        for (auto same : sames)
+        {
+            if (same)
+            {
+                ++count;
+            }
+        }
+
+        return count;
+    }
+};
+} // namespace detail
+
+template<typename T, typename... Ts>
+inline constexpr std::size_t
+    type_count_v = detail::type_count_helper{}({std::is_same_v<T, Ts>...});
+
+template<typename T, typename... Ts>
+struct type_count : std::integral_constant<std::size_t, type_count_v<T, Ts...>>
+{};
+
+/// counts how often a type is repeated in a pack
+
+namespace detail
+{
+
+struct type_unique_helper
+{
+    constexpr bool
+    operator()(std::initializer_list<bool> sameness) const noexcept
+    {
+        bool found = false;
+
+        for (auto same : sameness)
+        {
+            if (same)
+            {
+                if (found)
+                {
+                    return false;
+                }
+
+                found = true;
+            }
+        }
+
+        return found;
+    }
+};
+
+} // namespace detail
+
+template<typename T, typename... Ts>
+inline constexpr std::size_t
+    type_unique_v = detail::type_unique_helper{}({std::is_same_v<T, Ts>...});
+
+template<typename T, typename... Ts>
+struct type_unique : std::bool_constant<type_unique_v<T, Ts...>>
+{};
 
 namespace detail
 {

--- a/include/ely/variant.hpp
+++ b/include/ely/variant.hpp
@@ -162,7 +162,7 @@ public:
     constexpr NoIndex(std::size_t)
     {}
 
-    constexpr operator std::size_t() const noexcept
+    ELY_ALWAYS_INLINE constexpr operator std::size_t() const noexcept
     {
         return 0;
     }
@@ -195,7 +195,7 @@ struct VariantBase
 struct VariantAccess
 {
     template<std::size_t I, typename V>
-    static constexpr auto&& get_unchecked(V&& v) noexcept
+    ELY_ALWAYS_INLINE static constexpr auto&& get_unchecked(V&& v) noexcept
     {
         return ely::get_unchecked<I>((static_cast<V&&>(v).get_union()));
     }
@@ -207,7 +207,8 @@ struct is_derived_from_variant : std::is_base_of<ely::detail::VariantBase, T>
 } // namespace detail
 
 template<std::size_t I, typename V>
-constexpr auto get_unchecked(V&& v) noexcept -> std::enable_if_t<
+ELY_ALWAYS_INLINE constexpr auto
+get_unchecked(V&& v) noexcept -> std::enable_if_t<
     detail::is_derived_from_variant<ely::remove_cvref_t<V>>::value,
     decltype(ely::detail::VariantAccess::get_unchecked<I>(static_cast<V&&>(v)))>
 {
@@ -233,48 +234,50 @@ class VariantStorage : private EBOPair<ely::Union<Ts..., VariantUninit>,
                           variant_index_t<sizeof...(Ts)>>;
 
 protected:
-    constexpr VariantStorage(VariantUninit) noexcept
+    ELY_ALWAYS_INLINE constexpr VariantStorage(VariantUninit) noexcept
         : base_(std::piecewise_construct,
                 std::forward_as_tuple(std::in_place_index<sizeof...(Ts)>),
                 std::forward_as_tuple())
     {}
 
 public:
-    constexpr VariantStorage()
+    ELY_ALWAYS_INLINE constexpr VariantStorage()
         : base_(std::piecewise_construct,
                 std::forward_as_tuple(std::in_place_index<0>),
                 std::forward_as_tuple(variant_index_t<sizeof...(Ts)>{}))
     {}
 
-    constexpr ely::Union<Ts..., VariantUninit>& get_union() & noexcept
+    ELY_ALWAYS_INLINE constexpr ely::Union<Ts..., VariantUninit>&
+    get_union() & noexcept
     {
         return this->first();
     }
 
-    constexpr const ely::Union<Ts..., VariantUninit>&
+    ELY_ALWAYS_INLINE constexpr const ely::Union<Ts..., VariantUninit>&
     get_union() const& noexcept
     {
         return this->first();
     }
 
-    constexpr ely::Union<Ts..., VariantUninit>&& get_union() && noexcept
+    ELY_ALWAYS_INLINE constexpr ely::Union<Ts..., VariantUninit>&&
+    get_union() && noexcept
     {
         return std::move(*this).first();
     }
 
-    constexpr const ely::Union<Ts..., VariantUninit>&&
+    ELY_ALWAYS_INLINE constexpr const ely::Union<Ts..., VariantUninit>&&
     get_union() const&& noexcept
     {
         return std::move(*this).first();
     }
 
-    constexpr std::size_t index() const noexcept
+    ELY_ALWAYS_INLINE constexpr std::size_t index() const noexcept
     {
         return static_cast<std::size_t>(this->second());
     }
 
 protected:
-    constexpr void set_index(std::size_t new_idx) noexcept
+    ELY_ALWAYS_INLINE constexpr void set_index(std::size_t new_idx) noexcept
     {
         base_::second() = static_cast<variant_index_t<sizeof...(Ts)>>(new_idx);
     }
@@ -311,7 +314,8 @@ class VariantDestructor;
 
 VARIANT_IMPL(ely::detail::Availability::TriviallyAvailable,
              ~VariantDestructor() = default;
-             , constexpr void destroy_unchecked() noexcept {});
+             ,
+             ELY_ALWAYS_INLINE constexpr void destroy_unchecked() noexcept {});
 
 VARIANT_IMPL(
     ely::detail::Availability::Available,
@@ -369,8 +373,9 @@ VARIANT_IMPL(ely::detail::Availability::TriviallyAvailable,
              VariantCopyConstruct(const VariantCopyConstruct&) = default;);
 VARIANT_IMPL(
     ely::detail::Availability::Available,
-    constexpr VariantCopyConstruct(const VariantCopyConstruct& other) noexcept(
-        (std::is_nothrow_copy_constructible_v<Ts> && ...))
+    ELY_ALWAYS_INLINE constexpr VariantCopyConstruct(
+        const VariantCopyConstruct&
+            other) noexcept((std::is_nothrow_copy_constructible_v<Ts> && ...))
     : base_(VariantUninit{}) {
         this->set_index(other.index());
         dispatch_index<sizeof...(Ts)>(
@@ -418,8 +423,9 @@ VARIANT_IMPL(ely::detail::Availability::TriviallyAvailable,
              VariantMoveConstruct(VariantMoveConstruct&&) = default;);
 VARIANT_IMPL(
     ely::detail::Availability::Available,
-    constexpr VariantMoveConstruct(VariantMoveConstruct&& other) noexcept(
-        (std::is_nothrow_move_constructible_v<Ts> && ...))
+    ELY_ALWAYS_INLINE constexpr VariantMoveConstruct(
+        VariantMoveConstruct&&
+            other) noexcept((std::is_nothrow_move_constructible_v<Ts> && ...))
     : base_(VariantUninit{}) {
         this->set_index(other.index());
         dispatch_index<sizeof...(Ts)>(
@@ -468,7 +474,7 @@ VARIANT_IMPL(ely::detail::Availability::TriviallyAvailable,
              VariantCopyAssign& operator=(const VariantCopyAssign&) = default;);
 VARIANT_IMPL(
     ely::detail::Availability::Available,
-    constexpr VariantCopyAssign&
+    ELY_ALWAYS_INLINE constexpr VariantCopyAssign&
     operator=(const VariantCopyAssign& other) noexcept(
         (std::is_nothrow_copy_constructible_v<Ts> && ...)) {
         this->destroy_unchecked();
@@ -520,7 +526,7 @@ VARIANT_IMPL(ely::detail::Availability::TriviallyAvailable,
              VariantMoveAssign& operator=(VariantMoveAssign&&) = default;);
 VARIANT_IMPL(
     ely::detail::Availability::Available,
-    constexpr VariantMoveAssign&
+    ELY_ALWAYS_INLINE constexpr VariantMoveAssign&
     operator=(VariantMoveAssign&& other) noexcept(
         (std::is_nothrow_move_constructible_v<Ts> && ...)) {
         this->destroy_unchecked();
@@ -565,7 +571,8 @@ public:
     Variant& operator=(Variant&&) = default;
 
     template<std::size_t I, typename... Args>
-    explicit constexpr Variant(std::in_place_index_t<I>, Args&&... args)
+    ELY_ALWAYS_INLINE explicit constexpr Variant(std::in_place_index_t<I>,
+                                                 Args&&... args)
         : base_(detail::VariantUninit{})
     {
         this->set_index(I);
@@ -573,7 +580,8 @@ public:
     }
 
     template<typename T, typename... Args>
-    explicit constexpr Variant(std::in_place_type_t<T>, Args&&... args)
+    ELY_ALWAYS_INLINE explicit constexpr Variant(std::in_place_type_t<T>,
+                                                 Args&&... args)
         : Variant(std::in_place_index<detail::FindElementIndex<T, Ts...>>,
                   static_cast<Args&&>(args)...)
     {}
@@ -581,7 +589,7 @@ public:
     template<typename U,
              typename = std::enable_if_t<
                  !std::is_same_v<Variant<Ts...>, ely::remove_cvref_t<U>>>>
-    constexpr Variant(U&& u)
+    ELY_ALWAYS_INLINE constexpr Variant(U&& u)
         : Variant(std::in_place_index<detail::ResolveOverloadIndex<U, Ts...>>,
                   static_cast<U&&>(u))
     {}
@@ -590,7 +598,7 @@ public:
     using base_::index;
 
     template<typename F>
-    constexpr decltype(auto) visit(F&& fn) &
+    ELY_ALWAYS_INLINE constexpr decltype(auto) visit(F&& fn) &
     {
         using ely::get_unchecked;
 
@@ -608,7 +616,7 @@ public:
     }
 
     template<typename F>
-    constexpr decltype(auto) visit(F&& fn) const&
+    ELY_ALWAYS_INLINE constexpr decltype(auto) visit(F&& fn) const&
     {
         using ely::get_unchecked;
 
@@ -626,7 +634,7 @@ public:
     }
 
     template<typename F>
-    constexpr decltype(auto) visit(F&& fn) &&
+    ELY_ALWAYS_INLINE constexpr decltype(auto) visit(F&& fn) &&
     {
         using ely::get_unchecked;
 
@@ -644,7 +652,7 @@ public:
     }
 
     template<typename F>
-    constexpr decltype(auto) visit(F&& fn) const&&
+    ELY_ALWAYS_INLINE constexpr decltype(auto) visit(F&& fn) const&&
     {
         using ely::get_unchecked;
 
@@ -663,7 +671,8 @@ public:
 };
 
 template<std::size_t I, typename... Ts>
-constexpr bool holds_alternative(const Variant<Ts...>& v) noexcept
+ELY_ALWAYS_INLINE constexpr bool
+holds_alternative(const Variant<Ts...>& v) noexcept
 {
     return ely::detail::dispatch_index<sizeof...(Ts)>(
         [&](auto j) {
@@ -674,14 +683,15 @@ constexpr bool holds_alternative(const Variant<Ts...>& v) noexcept
 }
 
 template<std::size_t I, typename... Ts>
-constexpr bool holds(const Variant<Ts...>& v) noexcept
+ELY_ALWAYS_INLINE constexpr bool holds(const Variant<Ts...>& v) noexcept
 {
     using ely::holds_alternative;
     return holds_alternative<I>(v);
 }
 
 template<typename T, typename... Ts>
-constexpr bool holds_alternative(const Variant<Ts...>& v) noexcept
+ELY_ALWAYS_INLINE constexpr bool
+holds_alternative(const Variant<Ts...>& v) noexcept
 {
     return ely::detail::dispatch_index<sizeof...(Ts)>(
         [&](auto i) {
@@ -693,7 +703,7 @@ constexpr bool holds_alternative(const Variant<Ts...>& v) noexcept
 }
 
 template<typename T, typename... Ts>
-constexpr bool holds(const Variant<Ts...>& v) noexcept
+ELY_ALWAYS_INLINE constexpr bool holds(const Variant<Ts...>& v) noexcept
 {
     return ely::holds_alternative<T>(v);
 }

--- a/include/ely/variant.hpp
+++ b/include/ely/variant.hpp
@@ -627,6 +627,26 @@ constexpr bool holds(const Variant<Ts...>& v) noexcept
     return ely::holds_alternative<T>(v);
 }
 
+template<
+    typename F,
+    typename V,
+    typename R = std::invoke_result_t<F,
+                                      decltype(ely::get_unchecked<0>(
+                                          std::declval<V>()))>
+               ELY_ALWAYS_INLINE constexpr std::enable_if_t<
+            ely::detail::is_derived_from_variant<ely::remove_cvref_t<V>>::value,
+            R> visit(F&& fn, V&& v)
+{
+    return ely::detail::dispatch_index<
+        std::variant_size_v<ely::remove_cvref_t<V>>>(
+        [&](auto i) -> R {
+            constexpr auto I = decltype(i)::value;
+            return std::invoke(static_cast<F&&>(fn),
+                               ely::get_unchecked<I>(static_cast<V&&>(v)));
+        },
+        v.index());
+}
+
 template<typename V,
          typename F,
          typename R = std::invoke_result_t<

--- a/include/ely/variant.hpp
+++ b/include/ely/variant.hpp
@@ -627,16 +627,16 @@ constexpr bool holds(const Variant<Ts...>& v) noexcept
     return ely::holds_alternative<T>(v);
 }
 
-template<
-    typename F,
-    typename V,
-    typename R = std::invoke_result_t<F,
-                                      decltype(ely::get_unchecked<0>(
-                                          std::declval<V>()))>
-               ELY_ALWAYS_INLINE constexpr std::enable_if_t<
-            ely::detail::is_derived_from_variant<ely::remove_cvref_t<V>>::value,
-            R> visit(F&& fn, V&& v)
+template<typename F, typename V>
+ELY_ALWAYS_INLINE constexpr std::enable_if_t<
+    ely::detail::is_derived_from_variant<ely::remove_cvref_t<V>>::value,
+    std::invoke_result_t<F,
+                         decltype((ely::get_unchecked<0>(std::declval<V>())))>>
+visit(F&& fn, V&& v)
 {
+    using R = std::invoke_result_t<F,
+                                   decltype((ely::get_unchecked<0>(
+                                       std::declval<V>())))>;
     return ely::detail::dispatch_index<
         std::variant_size_v<ely::remove_cvref_t<V>>>(
         [&](auto i) -> R {
@@ -647,15 +647,11 @@ template<
         v.index());
 }
 
-template<typename V,
-         typename F,
-         typename R = std::invoke_result_t<
-             F,
-             decltype(ely::get_unchecked<0>(std::declval<V>()))>>
+template<typename R, typename F, typename V>
 ELY_ALWAYS_INLINE constexpr std::enable_if_t<
     ely::detail::is_derived_from_variant<ely::remove_cvref_t<V>>::value,
     R>
-visit(V&& v, F&& fn)
+visit(F&& fn, V&& v)
 {
     return ely::detail::dispatch_index<
         std::variant_size_v<ely::remove_cvref_t<V>>>(

--- a/src/ely.cpp
+++ b/src/ely.cpp
@@ -27,7 +27,7 @@ void scan_stream(std::string_view                         src,
     {
         auto lexeme = *it;
 
-        if (!ely::lexeme_is_atmosphere(lexeme.kind))
+        if (!lexeme.kind.is_atmosphere())
         {
             std::cout << std::string_view{lexeme.start, lexeme.size()} << '\n';
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,8 @@ set(ELY_TESTS
 
 set(TESTS
     union
-    variant)
+    variant
+    pair)
 
 find_package(doctest REQUIRED)
 

--- a/test/pair.cpp
+++ b/test/pair.cpp
@@ -1,0 +1,57 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <type_traits>
+
+#include <ely/pair.hpp>
+
+struct Empty1
+{
+    Empty1() = default;
+
+    Empty1(int i)
+    {}
+};
+struct Empty2
+{
+    Empty2() = default;
+
+    Empty2(float f)
+    {}
+};
+
+TEST_CASE("pair")
+{
+    SUBCASE("empty")
+    {
+        SUBCASE("default")
+        {
+            auto p = ely::EBOPair<Empty1, Empty2>{};
+
+            static_assert(std::is_empty_v<decltype(p)>);
+            static_assert(std::is_trivial_v<decltype(p)>);
+        }
+
+        SUBCASE("construct")
+        {
+            auto p = ely::EBOPair<Empty1, Empty2>{5, 5.f};
+        }
+    }
+
+    SUBCASE("empty same")
+    {
+        auto p = ely::EBOPair<Empty1, Empty1>{5, 5};
+
+        static_assert(std::is_empty_v<decltype(p)>);
+        static_assert(std::is_trivial_v<decltype(p)>);
+    }
+
+    SUBCASE("half empty")
+    {
+        auto p = ely::EBOPair<Empty1, int>{};
+
+        static_assert(sizeof(p) == sizeof(int));
+
+        REQUIRE_EQ(p.second(), 0);
+    }
+}

--- a/test/union.cpp
+++ b/test/union.cpp
@@ -14,12 +14,14 @@ using ely::get_unchecked;
 
 TEST_CASE("Union")
 {
-    // auto empty = ely::Union<>{};
-
-    // static_assert(std::is_empty_v<decltype(empty)>);
-
     SUBCASE("empty optimization")
     {
+        // this should be trivially contructible
+        auto empty = ely::Union<>{};
+
+        // checking whether a union without members takes up any space
+        static_assert(std::is_empty_v<decltype(empty)>);
+
         // testing for EBO
         static_assert(std::is_empty_v<ely::Union<NoData>>);
         // testing for EBO with multiple same types
@@ -79,7 +81,7 @@ TEST_CASE("Union")
         REQUIRE_EQ(get_unchecked<1>(u), 10);
 
         // can emplace without destroy since int is trivially destructible
-        emplace<3>(u, {1, 2, 3, 4, 5});
+        emplace<3>(u, {1, 2, 3, 4, 5}); // initializer list constructor
 
         REQUIRE_EQ(get_unchecked<3>(u).size(), 5);
         destroy<3>(u);

--- a/test/union.cpp
+++ b/test/union.cpp
@@ -8,9 +8,9 @@
 class NoData
 {};
 
-using ely::get_unchecked;
 using ely::destroy;
 using ely::emplace;
+using ely::get_unchecked;
 
 TEST_CASE("Union")
 {
@@ -20,8 +20,11 @@ TEST_CASE("Union")
 
     SUBCASE("empty optimization")
     {
-        // not yet implemented
-        // static_assert(std::is_empty_v<ely::Union<NoData>>);
+        // testing for EBO
+        static_assert(std::is_empty_v<ely::Union<NoData>>);
+        // testing for EBO with multiple same types
+        static_assert(
+            std::is_empty_v<ely::Union<NoData, NoData, NoData, NoData>>);
     }
 
     SUBCASE("default construct")

--- a/test/union.cpp
+++ b/test/union.cpp
@@ -18,6 +18,7 @@ TEST_CASE("Union")
     {
         // this should be trivially contructible
         auto empty = ely::Union<>{};
+        static_assert(std::is_trivial_v<decltype(empty)>);
 
         // checking whether a union without members takes up any space
         static_assert(std::is_empty_v<decltype(empty)>);

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -32,16 +32,18 @@ TEST_CASE("Variant")
 
         REQUIRE_EQ(v.index(), 2); // require std::string
 
-        REQUIRE(visit(v, [](auto x) {
-            if constexpr (std::is_same_v<std::string, decltype(x)>)
-            {
-                return x == "hello world";
-            }
-            else
-            {
-                return false;
-            }
-        }));
+        REQUIRE(visit(
+            [](auto x) {
+                if constexpr (std::is_same_v<std::string, decltype(x)>)
+                {
+                    return x == "hello world";
+                }
+                else
+                {
+                    return false;
+                }
+            },
+            v));
 
         auto v2 = v;
 
@@ -50,8 +52,7 @@ TEST_CASE("Variant")
 
     SUBCASE("construct in_place_type")
     {
-        auto v = ely::Variant<int, float, bool>(
-            std::in_place_type<float>, 5);
+        auto v = ely::Variant<int, float, bool>(std::in_place_type<float>, 5);
         REQUIRE_EQ(v.index(), 1);
 
         SUBCASE("copy")

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -23,6 +23,20 @@ TEST_CASE("Variant")
     {
         auto v = ely::Variant<int, float, std::string>{"hello world"};
 
+        SUBCASE("default")
+        {
+            SUBCASE("trivial")
+            {
+                auto v2 = ely::Variant<int, float>{};
+            }
+
+            SUBCASE("nontrivial")
+            {
+                auto v2 = ely::Variant<std::string, int>{};
+                REQUIRE_EQ(v2.index(), 0);
+            }
+        }
+
         using v_ty = decltype(v);
 
         static_assert(std::is_copy_constructible_v<v_ty>);


### PR DESCRIPTION
This brings several improvements to the current Variant implementation.
- Union now allows EBO in the cases that all variants are trivial and empty
- Variant uses EBOPair to reduce its footprint on empty unions